### PR TITLE
Change scissor volume to 145 mL

### DIFF
--- a/data/json/items/tool/stationary.json
+++ b/data/json/items/tool/stationary.json
@@ -54,7 +54,7 @@
     "description": "These are a long pair of heavy-duty scissors.  Use scissors to cut items made from cotton (like clothing) into rags.",
     "ascii_picture": "scissors",
     "weight": "113 g",
-    "volume": "250 ml",
+    "volume": "145 ml",
     "price": 400,
     "price_postapoc": 10,
     "to_hit": -1,


### PR DESCRIPTION
#### Summary

Content "Change scissors to more reasonable volume"

#### Purpose of change

Scissor volume appears to be just a default guess (250 ml), which doesn't fit into the first aid kit.

#### Describe the solution

Change to 145 ml. I don't know if just this will make it fit, but it's a step in the right direction.